### PR TITLE
#34 Serving protocol over HTTP

### DIFF
--- a/src/server/routes/router.js
+++ b/src/server/routes/router.js
@@ -10,6 +10,8 @@ router.post('/register', registerController.post())
 router.post('/login', logInUser(), 
 	(req, res) => responseManager.sendResponse(res, responseManager.MESSAGES.successes.OK))
 
+router.use('/protocol', express.static(path.join(process.cwd(), '/protocol')))
+
 if (config.devPropeties.devMode) 
 	router.use('/test', express.static(path.join(process.cwd(), '/.tests/tools')))
 


### PR DESCRIPTION
**Reference to related ticket:**
resolves #34 
**Description of changes:**

- Added serving files from `server/protocol/` directory through endpoint `host/protocol`.