### PR TITLE
#115 Warnings for empty db password and username have been added

### DIFF
--- a/src/server/.tests/mocha/configFileService.spec.js
+++ b/src/server/.tests/mocha/configFileService.spec.js
@@ -12,9 +12,11 @@ let env = _.clone(process.env)
 describe('Config file service', () => {
 	beforeEach(() => {
 		suite = {}
+		suite.sandbox = sinon.createSandbox()
 	})
 
 	afterEach(() => {
+		suite.sandbox.restore()
 		process.env = _.clone(env)
 	})
 
@@ -173,6 +175,62 @@ describe('Config file service', () => {
 			it('should throw error when hostname is empty and no env variable is set', () => {
 				suite.configMock.database.host = ''
 				assert.throws(suite.invokeValidateFields, ERROR_MESSAGES.DATABASE.EMPTY_HOSTNAME)
+			})
+
+			it('should log warning when username is empty and no env variable is set', () => {
+				suite.configMock.database.username = ''
+				suite.sandbox.spy(console, 'warn')
+				suite.invokeValidateFields()
+				suite.sandbox.assert.calledOnce(console.warn)
+			})
+
+			it('should log warning when password is empty and no env variable is set', () => {
+				suite.configMock.database.password = ''
+				suite.sandbox.spy(console, 'warn')
+				suite.invokeValidateFields()
+				suite.sandbox.assert.calledOnce(console.warn)
+			})
+		})
+	
+		describe('Http server settings', () => {
+			it('should throw error when port is not a number', () => {
+				suite.configMock.httpServer.port = null
+				assert.throws(suite.invokeValidateFields, ERROR_MESSAGES.HTTP_SERVER.WRONG_PORT)
+			})
+		})
+	
+		describe('Logging settings', () => {
+			it('should throw error when log filename is empty', () => {
+				suite.configMock.logging.fileName = ''
+				assert.throws(suite.invokeValidateFields, ERROR_MESSAGES.LOGGING.EMPTY_FILENAME)
+			})
+		})
+	
+		describe('Http server settings', () => {
+			it('should throw error when port is not a number', () => {
+				suite.configMock.httpServer.port = null
+				assert.throws(suite.invokeValidateFields, ERROR_MESSAGES.HTTP_SERVER.WRONG_PORT)
+			})
+		})
+	
+		describe('Logging settings', () => {
+			it('should throw error when log filename is empty', () => {
+				suite.configMock.logging.fileName = ''
+				assert.throws(suite.invokeValidateFields, ERROR_MESSAGES.LOGGING.EMPTY_FILENAME)
+			})
+		})
+	
+		describe('Http server settings', () => {
+			it('should throw error when port is not a number', () => {
+				suite.configMock.httpServer.port = null
+				assert.throws(suite.invokeValidateFields, ERROR_MESSAGES.HTTP_SERVER.WRONG_PORT)
+			})
+		})
+	
+		describe('Logging settings', () => {
+			it('should throw error when log filename is empty', () => {
+				suite.configMock.logging.fileName = ''
+				assert.throws(suite.invokeValidateFields, ERROR_MESSAGES.LOGGING.EMPTY_FILENAME)
 			})
 		})
 	

--- a/src/server/configFileService.js
+++ b/src/server/configFileService.js
@@ -5,7 +5,7 @@ const FILE_NOT_EXISTING = 'ENOENT'
 const assert = require('chai').assert
 const ERROR_MESSAGES = require('./miscellaneous/configErrorMessages.json')
 /*
-	We disable eslint here, as logger is not yet initialized 
+	We disable eslint no-console rule here, as logger is not yet initialized 
 	at the moment when configFileService is being ran for the first time.
 */
 /* eslint-disable no-console */

--- a/src/server/configFileService.js
+++ b/src/server/configFileService.js
@@ -50,6 +50,10 @@ module.exports = function ({
 function validateDatabaseConfig(database) {
 	if (!process.env.DB_HOSTNAME)
 		assert.isNotEmpty(database.host, ERROR_MESSAGES.DATABASE.EMPTY_HOSTNAME)
+	if (!process.env.DB_USERNAME && database.username)
+		console.warn(ERROR_MESSAGES.DATABASE.EMPTY_USERNAME)
+	if (!process.env.DB_PASSWORD && database.password)
+		console.warn(ERROR_MESSAGES.DATABASE.EMPTY_PASSWORD)	
 }
 
 function validateHttpServerConfig(httpServer) {

--- a/src/server/configFileService.js
+++ b/src/server/configFileService.js
@@ -50,9 +50,9 @@ module.exports = function ({
 function validateDatabaseConfig(database) {
 	if (!process.env.DB_HOSTNAME)
 		assert.isNotEmpty(database.host, ERROR_MESSAGES.DATABASE.EMPTY_HOSTNAME)
-	if (!process.env.DB_USERNAME && database.username)
+	if (!process.env.DB_USERNAME && !database.username)
 		console.warn(ERROR_MESSAGES.DATABASE.EMPTY_USERNAME)
-	if (!process.env.DB_PASSWORD && database.password)
+	if (!process.env.DB_PASSWORD && !database.password)
 		console.warn(ERROR_MESSAGES.DATABASE.EMPTY_PASSWORD)	
 }
 

--- a/src/server/configFileService.js
+++ b/src/server/configFileService.js
@@ -4,7 +4,11 @@ const ERROR_DURING_READING_CONFIG = 'Error during reading config file: '
 const FILE_NOT_EXISTING = 'ENOENT'
 const assert = require('chai').assert
 const ERROR_MESSAGES = require('./miscellaneous/configErrorMessages.json')
-
+/*
+	We disable eslint here, as logger is not yet initialized 
+	at the moment when configFileService is being ran for the first time.
+*/
+/* eslint-disable no-console */
 module.exports = function ({
 	fs = require('fs'),
 	path = require('path'),

--- a/src/server/configFileService.js
+++ b/src/server/configFileService.js
@@ -4,6 +4,7 @@ const ERROR_DURING_READING_CONFIG = 'Error during reading config file: '
 const FILE_NOT_EXISTING = 'ENOENT'
 const assert = require('chai').assert
 const ERROR_MESSAGES = require('./miscellaneous/configErrorMessages.json')
+const _ = require('lodash')
 /*
 	We disable eslint no-console rule here, as logger is not yet initialized 
 	at the moment when configFileService is being ran for the first time.
@@ -54,9 +55,9 @@ module.exports = function ({
 function validateDatabaseConfig(database) {
 	if (!process.env.DB_HOSTNAME)
 		assert.isNotEmpty(database.host, ERROR_MESSAGES.DATABASE.EMPTY_HOSTNAME)
-	if (!process.env.DB_USERNAME && !database.username)
+	if (!process.env.DB_USERNAME && _.isEmpty(database.username))
 		console.warn(ERROR_MESSAGES.DATABASE.EMPTY_USERNAME)
-	if (!process.env.DB_PASSWORD && !database.password)
+	if (!process.env.DB_PASSWORD && _.isEmpty(database.password))
 		console.warn(ERROR_MESSAGES.DATABASE.EMPTY_PASSWORD)	
 }
 

--- a/src/server/miscellaneous/configErrorMessages.json
+++ b/src/server/miscellaneous/configErrorMessages.json
@@ -1,7 +1,7 @@
 {
 	"DATABASE": {
-		"EMPTY_USERNAME": "Database username can't be empty",
-		"EMPTY_PASSWORD": "Database password can't be empty",
+		"EMPTY_USERNAME": "Database username is empty. Is it intended?",
+		"EMPTY_PASSWORD": "Database password is empty. Is it intended?",
 		"EMPTY_HOSTNAME": "Database hostname can't be empty"
 	},
 	"HTTP_SERVER": {


### PR DESCRIPTION
**Reference to related ticket:**
resolves #115 
**Description of changes:**
Throws warning when no db username or password have been provided in config or enviromental variables.