### PR TITLE
#162 CI failing during installing dependencies for Cypress

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/node:8.10.0-stretch-browsers
+      - image: circleci/node:9.10
         environment:
           DB_USERNAME: mongousradmin
           DB_PASSWORD: mongopassadmin

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/node:9.10
+      - image: circleci/node:8.9.4-stretch
         environment:
           DB_USERNAME: mongousradmin
           DB_PASSWORD: mongopassadmin

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/node:8.9.4
+      - image: circleci/node:8.10.0-stretch-browsers
         environment:
           DB_USERNAME: mongousradmin
           DB_PASSWORD: mongopassadmin


### PR DESCRIPTION
**Reference to related ticket:**

- #162 

**Description of changes:**

The issue was caused by Debian Jessie moving his repositories to a different URL.
Reference: https://discuss.circleci.com/t/convenience-images-update-changes-to-debian-mirror-for-browsers-tagged-image-variants/29293
To solve the issue I've changed the docker image that we base on to Debian Stretch Linux